### PR TITLE
New password field for the password update

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Updates the user's password by performing the following steps:
 
 ```js
 async updatePassword ({ request, auth }) {
-  const payload = request.only(['old_password', 'password', 'password_confirmation'])
+  const payload = request.only(['old_password', 'new_password', 'new_password_confirmation'])
   const user = auth.user
   await Persona.updatePassword(user, payload)
 }
@@ -216,7 +216,7 @@ Updates the user password using a token. This method performs the following chec
 ```js
 updatePasswordByToken ({ request, params }) {
   const token = params.token
-  const payload = request.only(['password', 'password_confirmation'])
+  const payload = request.only(['new_password', 'new_password_confirmation'])
 
   const user = await Persona.updatePasswordByToken(token, payload)
 }
@@ -297,13 +297,13 @@ Persona.updateEmailRules = function (userId) {
 Persona.updatePasswordRules = function (enforceOldPassword = true) {
   if (!enforceOldPassword) {
     return {
-      password: 'required|confirmed'
+      new_password: 'required|confirmed'
     }
   }
 
   return {
     old_password: 'required',
-    password: 'required|confirmed'
+    new_password: 'required|confirmed'
   }
 }
 ```

--- a/src/Persona.js
+++ b/src/Persona.js
@@ -52,7 +52,7 @@ class Persona {
      */
     this._oldPasswordField = `old_${this.config.password}`
     this._newPasswordField = `new_${this.config.password}`
-    this._passwordConfirmationField = `${this.config.password}_confirmation`
+    this._passwordConfirmationField = `new_${this.config.password}_confirmation`
 
     this.Hash = Hash
     this.Event = Event
@@ -674,7 +674,7 @@ class Persona {
    * @example
    * ```js
    * const user = auth.user
-   * const payload = request.only(['old_password', 'new_password', 'password_confirmation'])
+   * const payload = request.only(['old_password', 'new_password', 'new_password_confirmation'])
    *
    * await Persona.updatePassword(user, payload)
    * ```

--- a/src/Persona.js
+++ b/src/Persona.js
@@ -51,6 +51,7 @@ class Persona {
      * Varients of password fields
      */
     this._oldPasswordField = `old_${this.config.password}`
+    this._newPasswordField = `new_${this.config.password}`
     this._passwordConfirmationField = `${this.config.password}_confirmation`
 
     this.Hash = Hash
@@ -673,7 +674,7 @@ class Persona {
    * @example
    * ```js
    * const user = auth.user
-   * const payload = request.only(['old_password', 'password', 'password_confirmation'])
+   * const payload = request.only(['old_password', 'new_password', 'password_confirmation'])
    *
    * await Persona.updatePassword(user, payload)
    * ```
@@ -682,7 +683,7 @@ class Persona {
     await this.runValidation(payload, this.updatePasswordRules(), 'passwordUpdate')
 
     const oldPassword = payload[this._oldPasswordField]
-    const newPassword = this._getPassword(payload)
+    const newPassword = payload[this._newPasswordField]
     const existingOldPassword = this._getPassword(user)
 
     await this.verifyPassword(oldPassword, existingOldPassword, this._oldPasswordField)


### PR DESCRIPTION
new password field added because the login and register password is the same that the new password but in the custom errors a new password forgeted can not be the same error that a simple password forgeted