### PR TITLE
WIP: Generate tokens with variable expiry date

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -94,5 +94,15 @@ module.exports = {
   */
   validationMessages: () => {
     return {}
-  }
+  },
+
+  /*
+  |--------------------------------------------------------------------------
+  | Valid for
+  |--------------------------------------------------------------------------
+  |
+  | The default time in hours the token is valid for.
+  |
+  */
+  validFor: 24
 }

--- a/config/index.js
+++ b/config/index.js
@@ -86,6 +86,17 @@ module.exports = {
 
   /*
   |--------------------------------------------------------------------------
+  | Valid For
+  |--------------------------------------------------------------------------
+  |
+  | The default time in hours the token is valid for. This can be changed for
+  | an individual token by calling `isValidFor()` before generating it.
+  |
+  */
+  validFor: 24,
+
+  /*
+  |--------------------------------------------------------------------------
   | Validation messages
   |--------------------------------------------------------------------------
   |
@@ -94,15 +105,5 @@ module.exports = {
   */
   validationMessages: () => {
     return {}
-  },
-
-  /*
-  |--------------------------------------------------------------------------
-  | Valid for
-  |--------------------------------------------------------------------------
-  |
-  | The default time in hours the token is valid for.
-  |
-  */
-  validFor: 24
+  }
 }

--- a/src/Persona.js
+++ b/src/Persona.js
@@ -44,7 +44,8 @@ class Persona {
       model: 'App/Models/User',
       newAccountState: 'pending',
       verifiedAccountState: 'active',
-      dateFormat: 'YYYY-MM-DD HH:mm:ss'
+      dateFormat: 'YYYY-MM-DD HH:mm:ss',
+      validFor: 24
     })
 
     /**
@@ -157,7 +158,7 @@ class Persona {
     query
       .where('type', type)
       .where('is_revoked', false)
-      .where('updated_at', '>=', moment().subtract(24, 'hours').format(this.config.dateFormat))
+      .where('updated_at', '>=', moment().subtract(this.config.validFor, 'hours').format(this.config.dateFormat))
   }
 
   /**

--- a/src/Persona.js
+++ b/src/Persona.js
@@ -60,6 +60,7 @@ class Persona {
 
     this._encrypter = Encryption.getInstance({ hmac: false })
     this._model = null
+    this._validFor = null
   }
 
   /**
@@ -158,7 +159,7 @@ class Persona {
     query
       .where('type', type)
       .where('is_revoked', false)
-      .where('updated_at', '>=', moment().subtract(this.config.validFor, 'hours').format(this.config.dateFormat))
+      .where('expires_at', '>=', moment().format(this.config.dateFormat))
   }
 
   /**
@@ -188,7 +189,16 @@ class Persona {
     }
 
     const token = this._encrypter.encrypt(randtoken.generate(16))
-    await user.tokens().create({ type, token })
+    const expiresAt = moment().add(this.getValidFor(), 'hours').format(this.config.dateFormat)
+
+    this._validFor = null
+
+    await user.tokens().create({
+      type,
+      token,
+      expires_at: expiresAt
+    })
+
     return token
   }
 
@@ -275,6 +285,36 @@ class Persona {
    */
   getTable () {
     return this.getModel().table
+  }
+
+  /**
+   * Returns the duration in hours the a generated token should be valid for
+   *
+   * @method getValidFor
+   *
+   * @return {Number}
+   */
+  getValidFor () {
+    if (this._validFor) {
+      return this._validFor
+    }
+
+    return this.config.validFor
+  }
+
+  /**
+   * Sets the duration in hours the a generated token should be valid for
+   *
+   * @method isValidFor
+   *
+   * @param {Number} payload
+   *
+   * @return {Persona}
+   */
+  isValidFor (payload) {
+    this._validFor = payload
+
+    return this
   }
 
   /**

--- a/test/persona.spec.js
+++ b/test/persona.spec.js
@@ -206,7 +206,8 @@ test.group('Persona', (group) => {
       user_id: user.id,
       is_revoked: false,
       created_at: moment().subtract(2, 'days').format('YYYY-MM-DD HH:mm:ss'),
-      updated_at: moment().subtract(2, 'days').format('YYYY-MM-DD HH:mm:ss')
+      updated_at: moment().subtract(2, 'days').format('YYYY-MM-DD HH:mm:ss'),
+      expires_at: moment().subtract(1, 'days').format('YYYY-MM-DD HH:mm:ss')
     })
 
     assert.plan(2)
@@ -228,7 +229,8 @@ test.group('Persona', (group) => {
       user_id: user.id,
       is_revoked: false,
       created_at: moment().format('YYYY-MM-DD HH:mm:ss'),
-      updated_at: moment().format('YYYY-MM-DD HH:mm:ss')
+      updated_at: moment().format('YYYY-MM-DD HH:mm:ss'),
+      expires_at: moment().add(2, 'days').format('YYYY-MM-DD HH:mm:ss')
     })
 
     assert.plan(2)
@@ -250,7 +252,8 @@ test.group('Persona', (group) => {
       is_revoked: false,
       user_id: user.id,
       created_at: moment().format('YYYY-MM-DD HH:mm:ss'),
-      updated_at: moment().format('YYYY-MM-DD HH:mm:ss')
+      updated_at: moment().format('YYYY-MM-DD HH:mm:ss'),
+      expires_at: moment().add(2, 'days').format('YYYY-MM-DD HH:mm:ss')
     })
 
     await this.persona.verifyEmail('hello')
@@ -271,7 +274,8 @@ test.group('Persona', (group) => {
       is_revoked: false,
       user_id: user.id,
       created_at: moment().format('YYYY-MM-DD HH:mm:ss'),
-      updated_at: moment().format('YYYY-MM-DD HH:mm:ss')
+      updated_at: moment().format('YYYY-MM-DD HH:mm:ss'),
+      expires_at: moment().add(2, 'days').format('YYYY-MM-DD HH:mm:ss')
     })
 
     await this.persona.verifyEmail('hello')
@@ -604,7 +608,8 @@ test.group('Persona', (group) => {
       user_id: user.id,
       is_revoked: false,
       created_at: moment().format('YYYY-MM-DD HH:mm:ss'),
-      updated_at: moment().format('YYYY-MM-DD HH:mm:ss')
+      updated_at: moment().format('YYYY-MM-DD HH:mm:ss'),
+      expires_at: moment().add(2, 'days').format('YYYY-MM-DD HH:mm:ss')
     })
 
     try {
@@ -629,7 +634,8 @@ test.group('Persona', (group) => {
       user_id: user.id,
       is_revoked: false,
       created_at: moment().subtract(2, 'days').format('YYYY-MM-DD HH:mm:ss'),
-      updated_at: moment().subtract(2, 'days').format('YYYY-MM-DD HH:mm:ss')
+      updated_at: moment().subtract(2, 'days').format('YYYY-MM-DD HH:mm:ss'),
+      expires_at: moment().subtract(1, 'days').format('YYYY-MM-DD HH:mm:ss')
     })
 
     try {
@@ -655,7 +661,8 @@ test.group('Persona', (group) => {
       user_id: user.id,
       is_revoked: false,
       created_at: moment().format('YYYY-MM-DD HH:mm:ss'),
-      updated_at: moment().format('YYYY-MM-DD HH:mm:ss')
+      updated_at: moment().format('YYYY-MM-DD HH:mm:ss'),
+      expires_at: moment().add(2, 'days').format('YYYY-MM-DD HH:mm:ss')
     })
 
     await this.persona.updatePasswordByToken('hello', { password: 'newsecret', password_confirmation: 'newsecret' })
@@ -748,5 +755,36 @@ test.group('Persona', (group) => {
 
     assert.equal(users.size(), 1)
     assert.equal(users.first().email, 'foo@bar.com')
+  })
+
+  test('generated tokens are valid for 24 hours by default', async (assert) => {
+    const user = await getUser().create({
+      username: 'virk',
+      email: 'foo@bar.com',
+      account_status: 'active',
+      password: 'secret'
+    })
+
+    const token = await this.persona.generateToken(user, 'email')
+
+    const tokenEntity = await this.persona.getToken(token, 'email')
+    assert.equal(tokenEntity.expires_at, moment().add(1, 'days').format('YYYY-MM-DD HH:mm:ss'))
+  })
+
+  test('the expiry date for a tokens can be changed for each token', async (assert) => {
+    const user = await getUser().create({
+      username: 'virk',
+      email: 'foo@bar.com',
+      account_status: 'active',
+      password: 'secret'
+    })
+
+    const token = await this.persona.isValidFor(48).generateToken(user, 'email')
+    const tokenEntity = await this.persona.getToken(token, 'email')
+    assert.equal(tokenEntity.expires_at, moment().add(2, 'days').format('YYYY-MM-DD HH:mm:ss'))
+
+    const token1 = await this.persona.generateToken(user, 'password')
+    const tokenEntity1 = await this.persona.getToken(token1, 'password')
+    assert.equal(tokenEntity1.expires_at, moment().add(1, 'days').format('YYYY-MM-DD HH:mm:ss'))
   })
 })

--- a/test/setup.js
+++ b/test/setup.js
@@ -76,6 +76,7 @@ module.exports = {
       table.string('token').notNull()
       table.string('type').notNull()
       table.boolean('is_revoked').defaultsTo(false)
+      table.timestamp('expires_at').nullable()
       table.timestamps()
     })
   },


### PR DESCRIPTION
Hi @thetutlage 

I added the `expires_at` field to tokens as we discussed in #24. So far it works, but I have two questions I'd like to get your input on:

**1:**
In order to allow you to set a different duration for each token, I had two options: Add a parameter to all methods (`generateToken`, `register`, `updateEmail`, `updateProfile`) that generate a token, or add a chainable method. I went with the latter since it would have made it a bit awkward to pass the parameter down. And I especially didn't like the signature for `register`:

```js
async register (payload, callback, validFor = this.config.validFor) {
```

So currently I use the `isValidFor` method to set the parameter and return `this` to allow chaining. But this means I have to reset the value after generating a token. 

I'm not happy with either of those options. So I want to ask you what you prefer or if you have a better idea?

**2:**
What should happen with existing tokens when users upgrade?
Currently, I treat tokens without an expiry date as invalid. To make the migration easy we could add a fallback: If `expires_at` is null, we fall back to the previous behavior and check the `updated_at` field. However, this fallback would only ever be used for 24 hours after the upgrade.

I would prefer the fallback option. So I tried to construct a query, but it turns out to be quite difficult since the `query` parameter is sometimes a `user.tokens()` relationship which would lead to a wrong `or` clause.

This was my attempt: 
```js
  _addTokenConstraints (query, type) {
    const dateFormat = this.config.dateFormat

    query
      .where('type', type)
      .where('is_revoked', false)
      .where('expires_at', '>=', moment().format(dateFormat))
      .orWhere(function () {
        this.whereNull('expires_at')
          .where('type', type)
          .where('is_revoked', false)
          .where('updated_at', '>=', moment().subtract(24, 'hours').format(dateFormat))
      })
  }
```

Looking forward to your feedback.